### PR TITLE
Fixed BICO memory deallocation

### DIFF
--- a/src/BICO/master.h
+++ b/src/BICO/master.h
@@ -137,16 +137,16 @@ MASTER::~MASTER()
 {
     for (int i = 0; i < numberOfPoints; i++)
     {
-        delete points[i]->second;
+        delete[] points[i]->second;
         delete points[i];
     }
     for (int i = 0; i < k; i++)
     {
-        delete centers[i];
-        delete finalcenters[i];
+        delete[] centers[i];
+        delete[] finalcenters[i];
     }
-    delete centers;
-    delete finalcenters;
+    delete[] centers;
+    delete[] finalcenters;
 }
 
 double***MASTER::run(double* finalWeights)


### PR DESCRIPTION
It appears that the BICO implementation does not deallocate arrays correctly. This should fix the problems and silence the warnings from valgrind.

This is in response to the issue brought up in the discussion of Pull-Request #5 

