### PR TITLE
Fix typo in BIRCH treshold -> threshold

### DIFF
--- a/R/DSC_BIRCH.R
+++ b/R/DSC_BIRCH.R
@@ -17,12 +17,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-DSC_BIRCH <- function(treshold, branching, maxLeaf, maxMem = 0, outlierThreshold = 0.25) {
+DSC_BIRCH <- function(threshold, branching, maxLeaf, maxMem = 0, outlierThreshold = 0.25) {
 
   structure(
     list(
       description = "BIRCH - Balanced Iterative Reducing Clustering using Hierarchies",
-      RObj = birch$new(treshold = treshold, branching=branching, maxLeaf=maxLeaf, maxMem=maxMem, outlierThreshold=outlierThreshold)
+      RObj = birch$new(threshold = threshold, branching=branching, maxLeaf=maxLeaf, maxMem=maxMem, outlierThreshold=outlierThreshold)
     ), class = c("DSC_BIRCH", "DSC_Micro", "DSC_R", "DSC")
   )
 }
@@ -32,14 +32,14 @@ birch <- setRefClass("BIRCH", fields = list(
 ))
 
 #  CF-Tree creation: Initializes an empty CF-Tree.
-# param treshold Specifies the treshold used to check whether a new datapoint can be absorbed or not.
+# param threshold Specifies the threshold used to check whether a new datapoint can be absorbed or not.
 # param branching Specifies the branching factor (maximum amount of child nodes for a nonleaf node) of the CF-Tree.
 # param maxLeaf Specifies the maximum number of entries within a leaf node.
 # param maxMemory Specifies the memory limitation for the whole CFTree in bytes. Default is 0, indicating no memory restriction.
 # param outlierThreshold Specifies the threshold for identifying outliers when rebuilding the CF-Tree.
 birch$methods(
-  initialize = function(treshold,branching,maxLeaf,maxMem,outlierThreshold){
-    C <<- new(BIRCH,treshold,branching,maxLeaf,maxMem,outlierThreshold) ## Exposed C class
+  initialize = function(threshold,branching,maxLeaf,maxMem,outlierThreshold){
+    C <<- new(BIRCH,threshold,branching,maxLeaf,maxMem,outlierThreshold) ## Exposed C class
     .self
   })
 

--- a/man/DSC_BIRCH.Rd
+++ b/man/DSC_BIRCH.Rd
@@ -4,10 +4,10 @@
 \alias{birch}
 \title{Balanced Iterative Reducing Clustering using Hierarchies}
 \usage{
-DSC_BIRCH(treshold, branching, maxLeaf, maxMem = 0, outlierThreshold = 0.25)
+DSC_BIRCH(threshold, branching, maxLeaf, maxMem = 0, outlierThreshold = 0.25)
 }
 \arguments{
-\item{treshold}{treshold used to check whether a new datapoint can be absorbed or not}
+\item{threshold}{threshold used to check whether a new datapoint can be absorbed or not}
 
 \item{branching}{branching factor (maximum amount of child nodes for a nonleaf node) of the CF-Tree.}
 
@@ -22,12 +22,12 @@ BIRCH builds a balanced-tree of Clustering Features (CFs) to summarize the strea
 A CF is a tuple (n, LS, SS) which represents a cluster by storing the number of elements (n), their linear sum (LS) and their squared sum (SS).
 Each new observation descends the tree by following its closest CF until a leaf node is reached.
 It is either merged into its closest leaf-CF or inserted as a new one.
-All leaf-CFs form the micro-clusters. Rebuilding the tree is realized by inserting all leaf-CF nodes into a new tree structure with an increased treshold.
+All leaf-CFs form the micro-clusters. Rebuilding the tree is realized by inserting all leaf-CF nodes into a new tree structure with an increased threshold.
 }
 \examples{
 stream <- DSD_Gaussians(k = 3, d = 2)
 
-BIRCH <- DSC_BIRCH(treshold = .1, branching = 8, maxLeaf = 20)
+BIRCH <- DSC_BIRCH(threshold = .1, branching = 8, maxLeaf = 20)
 update(BIRCH, stream, n = 500)
 
 plot(BIRCH,stream)

--- a/src/BIRCH.cpp
+++ b/src/BIRCH.cpp
@@ -9,13 +9,13 @@ public:
   CF::CFTree *tree = NULL;
 
   //' @title CF-Tree creation
-  //' @param treshold Specifies the treshold used to check whether a new datapoint can be absorbed or not.
+  //' @param threshold Specifies the threshold used to check whether a new datapoint can be absorbed or not.
   //' @param branching Specifies the branching factor (maximum amount of child nodes for a nonleaf node) of the CF-Tree.
   //' @param maxLeaf Specifies the maximum number of entries within a leaf node.
   //' @param maxMemory Specifies the memory limitation for the whole CFTree in bytes. Default is 0, indicating no memory restriction.
   //' @param outlierThreshold Specifies the threshold for identifying outliers when rebuilding the CF-Tree.
-  BIRCH(double treshold, int branching, int maxLeafEntries, int maxMemory, float outlierThreshold){
-    this->tree = new CF::CFTree(treshold,branching,maxLeafEntries,maxMemory,outlierThreshold);
+  BIRCH(double threshold, int branching, int maxLeafEntries, int maxMemory, float outlierThreshold){
+    this->tree = new CF::CFTree(threshold,branching,maxLeafEntries,maxMemory,outlierThreshold);
   }
 
   void insert(NumericVector v){
@@ -83,8 +83,8 @@ public:
 
   //' @title CF-Tree threshold
   //' @description Returns the current threshold of a CF-Tree
-  double getTreshold(){
-    return this->tree->getTreshold();
+  double getThreshold(){
+    return this->tree->getThreshold();
   }
 
   //' @title Deletes the whole tree structure
@@ -119,7 +119,7 @@ RCPP_EXPOSED_CLASS(BIRCH)
     .method("getCentroids", &BIRCH::getCentroids)
     .method("getWeights", &BIRCH::getWeights)
     .method("printTree", &BIRCH::printTree)
-    .method("getTreshold", &BIRCH::getTreshold)
+    .method("getThreshold", &BIRCH::getThreshold)
     .method("deleteTree", &BIRCH::deleteTree)
     ;
 

--- a/src/BIRCH/CFTree.hpp
+++ b/src/BIRCH/CFTree.hpp
@@ -14,7 +14,7 @@ namespace CF{
     class CFTree {
 
     public:
-        CFTree(double treshold, int branchingFactor, int maxLeafEntries, int maxMemory, float outlierThreshold);
+        CFTree(double threshold, int branchingFactor, int maxLeafEntries, int maxMemory, float outlierThreshold);
 
         ~CFTree();
 
@@ -28,11 +28,11 @@ namespace CF{
 
         void insert(ClusteringFeature *feature,CF::CFNode *node);
 
-        void rebuild(double treshold);
+        void rebuild(double threshold);
 
         void deleteTree(CFNode* node, int deleteLeafs);
 
-        void resetTreeWithNewTreshold(double treshold);
+        void resetTreeWithNewThreshold(double threshold);
 
         void removeOutliers(std::vector<CF::ClusteringFeature*>* cfs);
 
@@ -48,19 +48,19 @@ namespace CF{
 
         int getUsedMem();
 
-        double findNewTreshold(CFNode* node);
+        double findNewThreshold(CFNode* node);
 
-        double getTreshold();
+        double getThreshold();
 
     private:
         CFNode* root;
-        double treshold;
+        double threshold;
         unsigned int branchingFactor;
         int maxLeafEntries;
         int treeHeight;
         int usedMem;
         int maxMemory;
-        float outlierTreshold;
+        float outlierThreshold;
         std::vector<CF::ClusteringFeature*>* features;
         std::vector<CF::ClusteringFeature*>* outlier;
     };

--- a/src/BIRCH/ClusteringFeature.cpp
+++ b/src/BIRCH/ClusteringFeature.cpp
@@ -7,7 +7,7 @@
 
 namespace CF {
 
-bool ClusteringFeature::canAbsorb(CF::ClusteringFeature *newCF,bool diameter, double treshold){
+bool ClusteringFeature::canAbsorb(CF::ClusteringFeature *newCF,bool diameter, double threshold){
   ClusteringFeature f(newCF->getLs().size());
   f.add(newCF);
 
@@ -19,14 +19,14 @@ bool ClusteringFeature::canAbsorb(CF::ClusteringFeature *newCF,bool diameter, do
  // Rcpp::Rcout<<"InsertionCF n:"<<f.getN()<<std::endl;
  // Rcpp::Rcout<<"InsertionCF ss:"<<f.getSs()<<std::endl;
   if(diameter){
-    Rcpp::Rcout<<"Diameter: "<<f.getDiameter()<<" and Treshold: "<<treshold<<std::endl;
-    if(f.getDiameter()< treshold)
+    Rcpp::Rcout<<"Diameter: "<<f.getDiameter()<<" and Threshold: "<<threshold<<std::endl;
+    if(f.getDiameter()< threshold)
       return true;
     else return false;
   }
   else{
-    //Rcpp::Rcout<<"Radius: "<<f.getRadius()<<" and Treshold: "<<treshold<<std::endl;
-    if(f.getRadius()< treshold)
+    //Rcpp::Rcout<<"Radius: "<<f.getRadius()<<" and Threshold: "<<threshold<<std::endl;
+    if(f.getRadius()< threshold)
       return true;
       else return false;
   }

--- a/src/BIRCH/ClusteringFeature.hpp
+++ b/src/BIRCH/ClusteringFeature.hpp
@@ -20,7 +20,7 @@ namespace CF{
         ClusteringFeature(short dim);
     public:
 
-        bool canAbsorb(CF::ClusteringFeature *newCF,bool diameter, double treshold);
+        bool canAbsorb(CF::ClusteringFeature *newCF,bool diameter, double threshold);
 
         void add(CF::ClusteringFeature *feature);
 

--- a/tests/testthat/test-DSC_BIRCH.R
+++ b/tests/testthat/test-DSC_BIRCH.R
@@ -10,7 +10,7 @@ stream <- DSD_Gaussians(k = 3, noise = 0.05)
 context("DSC_BIRCH")
 
 # create clusterer with r = 0.05
-BIRCH <- DSC_BIRCH(treshold = .1, branching = 8, maxLeaf = 20)
+BIRCH <- DSC_BIRCH(threshold = .1, branching = 8, maxLeaf = 20)
 update(BIRCH, stream, n = 10000)
 
 BIRCH


### PR DESCRIPTION
Just a fix for a small (but consistent) typo in BIRCH. treshold -> threshold