### PR TITLE
tests: migration to testthat version 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,10 +45,11 @@ Suggests:
     knitr,
     rJava,
     RSQLite,
-    testthat
+    testthat (>= 3.0.0)
 LinkingTo: 
     BH,
     Rcpp
+Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,5 @@
-library("testthat")
+library(stream)
+library(testthat)
 
-library("stream")
 test_check("stream")
 

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,1 @@
+short_desc <- function(x) strsplit(description(x), " ", fixed = TRUE)[[1L]][1L]

--- a/tests/testthat/test-DSC_BICO.R
+++ b/tests/testthat/test-DSC_BICO.R
@@ -1,30 +1,25 @@
-library("stream")
-library("testthat")
-setwd(tempdir())
+test_that("DSC_BICO", {
+  ### read and reload write some DSCs (see if Cpp serialization works)
+  set.seed(0)
+  stream <- DSD_Gaussians(k = 3, noise = 0.05)
 
-### read and reload write some DSCs (see if Cpp serialization works)
-set.seed(0)
-stream <- DSD_Gaussians(k = 3, noise = 0.05)
+  ######################################################################
 
-######################################################################
-context("DSC_BICO")
+  # create clusterer with r = 0.05
+  BICO <- DSC_BICO(
+    k = 3,
+    p = 10,
+    space = 100,
+    iterations = 10
+  )
+  update(BICO, stream, n = 10000)
 
-# create clusterer with r = 0.05
-BICO <- DSC_BICO(
-  k = 3,
-  p = 10,
-  space = 100,
-  iterations = 10
-)
-update(BICO, stream, n = 10000)
-
-BICO
-
-## saveDSC is not implemented!
-#saveDSC(BICO, file="BICO.Rds")
-#db <- readDSC("BICO.Rds")
-#
-#expect_equal(BICO$RObj$micro, db$RObj$micro)
-#expect_equal(BICO$macro, db$macro)
-#
-#unlink("BICO.Rds")
+  ## saveDSC is not implemented!
+  # saveDSC(BICO, file="BICO.Rds")
+  # db <- readDSC("BICO.Rds")
+  #
+  # expect_equal(BICO$RObj$micro, db$RObj$micro)
+  # expect_equal(BICO$macro, db$macro)
+  #
+  # unlink("BICO.Rds")
+})

--- a/tests/testthat/test-DSC_BIRCH.R
+++ b/tests/testthat/test-DSC_BIRCH.R
@@ -1,27 +1,24 @@
-library("stream")
-library("testthat")
-setwd(tempdir())
+test_that("DSC_BIRCH", {
+  ### read and reload write some DSCs (see if Cpp serialization works)
+  set.seed(0)
+  stream <- DSD_Gaussians(k = 3, noise = 0.05)
 
-### read and reload write some DSCs (see if Cpp serialization works)
-set.seed(0)
-stream <- DSD_Gaussians(k = 3, noise = 0.05)
+  ######################################################################
 
-######################################################################
-context("DSC_BIRCH")
+  # create clusterer with r = 0.05
+  BIRCH <- DSC_BIRCH(threshold = .1,
+    branching = 8,
+    maxLeaf = 20)
+  update(BIRCH, stream, n = 10000)
 
-# create clusterer with r = 0.05
-BIRCH <- DSC_BIRCH(threshold = .1,
-  branching = 8,
-  maxLeaf = 20)
-update(BIRCH, stream, n = 10000)
+  BIRCH
 
-BIRCH
-
-## saveDSC is not implemented!
-#saveDSC(BIRCH, file="BIRCH.Rds")
-#db <- readDSC("BIRCH.Rds")
-#
-#expect_equal(BIRCH$RObj$micro, db$RObj$micro)
-#expect_equal(BIRCH$macro, db$macro)
-#
-#unlink("BIRCH.Rds")
+  ## saveDSC is not implemented!
+  #saveDSC(BIRCH, file="BIRCH.Rds")
+  #db <- readDSC("BIRCH.Rds")
+  #
+  #expect_equal(BIRCH$RObj$micro, db$RObj$micro)
+  #expect_equal(BIRCH$macro, db$macro)
+  #
+  #unlink("BIRCH.Rds")
+})

--- a/tests/testthat/test-DSC_read_write.R
+++ b/tests/testthat/test-DSC_read_write.R
@@ -1,8 +1,3 @@
-library("testthat")
-library("stream")
-
-setwd(tempdir())
-
 expect_equal_dsc_basics <- function (x,
   y,
   fields =
@@ -21,63 +16,59 @@ expect_equal_dsc_basics <- function (x,
 set.seed(0)
 stream <- DSD_Gaussians(k = 3, noise = 0.05)
 
-context("read/write DSC_DBSTREAM")
+test_that("read/write DSC_DBSTREAM", {
+  # create clusterer with r = 0.05
+  dsc <- DSC_DBSTREAM(r = .05)
+  update(dsc, stream, 10000)
+  dsc
 
-# create clusterer with r = 0.05
-dsc <- DSC_DBSTREAM(r = .05)
-update(dsc, stream, 10000)
-dsc
+  tf <- tempfile(fileext = ".rds")
+  on.exit(unlink(tf), add = TRUE)
+  saveDSC(dsc, file = tf)
+  dsc_read <- readDSC(tf)
+  dsc_read
 
-saveDSC(dsc, file = "dsc.Rds")
-dsc_read <- readDSC("dsc.Rds")
-dsc_read
+  #expect_equal(dsc$RObj$micro, dsc_read$RObj$micro)
+  expect_equal_dsc_basics(dsc$RObj, dsc_read$RObj)
 
-#expect_equal(dsc$RObj$micro, dsc_read$RObj$micro)
-expect_equal_dsc_basics(dsc$RObj, dsc_read$RObj)
+  # this should work, but has an issue with comparing the class
+  #expect_equal(dsc$macro$RObj, dsc_read$macro$RObj)
+  expect_equal_dsc_basics(dsc$macro$RObj, dsc_read$macro$RObj)
+})
 
-# this should work, but has an issue with comparing the class
-#expect_equal(dsc$macro$RObj, dsc_read$macro$RObj)
-expect_equal_dsc_basics(dsc$macro$RObj, dsc_read$macro$RObj)
+test_that("read/write DSC_TwoStage", {
+  dsc <- DSC_TwoStage(micro = DSC_DBSTREAM(r = .05),
+    macro = DSC_Kmeans(k = 3))
+  update(dsc, stream, 10000)
+  dsc
 
-# cleanup
-unlink("dsc.Rds")
+  tf <- tempfile(fileext = ".rds")
+  on.exit(unlink(tf), add = TRUE)
+  saveDSC(dsc, file = tf)
+  dsc_read <- readDSC(tf)
+  dsc_read
 
-######################################################################
-context("read/write DSC_TwoStage")
+  #expect_equal(dsc$micro$RObj, dsc_read$micro$RObj)
+  expect_equal_dsc_basics(dsc$micro$RObj, dsc_read$micro$RObj)
 
-dsc <- DSC_TwoStage(micro = DSC_DBSTREAM(r = .05),
-  macro = DSC_Kmeans(k = 3))
-update(dsc, stream, 10000)
-dsc
+  #expect_equal(dsc$macro$RObj, dsc_read$macro$RObj)
+  expect_equal_dsc_basics(dsc$macro$RObj, dsc_read$macro$RObj)
+})
 
-saveDSC(dsc, file = "dsc.Rds")
-dsc_read <- readDSC("dsc.Rds")
-dsc_read
+test_that("read/write DSC_DSTREAM", {
+  dsc <- DSC_DStream(grid = .1)
+  update(dsc, stream, 10000)
+  dsc
 
-#expect_equal(dsc$micro$RObj, dsc_read$micro$RObj)
-expect_equal_dsc_basics(dsc$micro$RObj, dsc_read$micro$RObj)
+  tf <- tempfile(fileext = ".rds")
+  on.exit(unlink(tf), add = TRUE)
+  saveDSC(dsc, file = tf)
+  dsc_read <- readDSC(tf)
+  dsc_read
 
-#expect_equal(dsc$macro$RObj, dsc_read$macro$RObj)
-expect_equal_dsc_basics(dsc$macro$RObj, dsc_read$macro$RObj)
+  #expect_equal(dsc$micro$RObj, dsc_read$micro$RObj)
+  expect_equal_dsc_basics(dsc$micro$RObj, dsc_read$micro$RObj)
 
-unlink("dsc.Rds")
-
-######################################################################
-context("read/write DSC_DSTREAM")
-
-dsc <- DSC_DStream(grid = .1)
-update(dsc, stream, 10000)
-dsc
-
-saveDSC(dsc, file = "dsc.Rds")
-dsc_read <- readDSC("dsc.Rds")
-dsc_read
-
-#expect_equal(dsc$micro$RObj, dsc_read$micro$RObj)
-expect_equal_dsc_basics(dsc$micro$RObj, dsc_read$micro$RObj)
-
-#expect_equal(dsc$macro$RObj, dsc_read$macro$RObj)
-expect_equal_dsc_basics(dsc$macro$RObj, dsc_read$macro$RObj)
-
-# cleanup
-unlink(c("dsc.Rds"))
+  #expect_equal(dsc$macro$RObj, dsc_read$macro$RObj)
+  expect_equal_dsc_basics(dsc$macro$RObj, dsc_read$macro$RObj)
+})

--- a/tests/testthat/test-DSD.R
+++ b/tests/testthat/test-DSD.R
@@ -1,188 +1,193 @@
-library(stream)
-library("testthat")
-setwd(tempdir())
-
 df <- data.frame(
   x = runif(100),
   y = runif(100),
   .class = sample(1:3, 100, replace = TRUE)
 )
 
+test_that("DSD_Memory", {
+  stream <- DSD_Memory(df)
+  reset_stream(stream)
+  points <- get_points(stream, n = 10, info = TRUE)
+  expect_identical(points, df[1:10, ])
 
-############################################################################
-context("DSD_Memory")
+  ### returned all 100 points
+  reset_stream(stream)
+  points <- get_points(stream, n = 100)
+  expect_identical(nrow(points), 100L)
+  expect_identical(ncol(points), ncol(df))
 
-stream <- DSD_Memory(df)
-reset_stream(stream)
-points <- get_points(stream, n = 10, info = TRUE)
-expect_equal(points, df[1:10, ])
-
-### returned all 100 points
-reset_stream(stream)
-points <- get_points(stream, n = 100)
-expect_equal(nrow(points), 100)
-expect_equal(ncol(points), ncol(df))
-
-### ask for too many
-reset_stream(stream)
-expect_warning(points <- get_points(stream, n = 101))
-expect_equal(nrow(points), 100)
+  ### ask for too many
+  reset_stream(stream)
+  expect_warning(points <- get_points(stream, n = 101))
+  expect_identical(nrow(points), 100L)
 
 
-### no more points available
-expect_warning(points <-
-    get_points(stream, n = 500,))
-expect_equal(nrow(points), 0)
-expect_equal(ncol(points), ncol(df))
+  ### no more points available
+  expect_warning(points <-
+      get_points(stream, n = 500,))
+  expect_identical(nrow(points), 0L)
+  expect_identical(ncol(points), ncol(df))
 
-### test stop
-stream <- DSD_Memory(df, outofpoints = "stop")
-expect_error(points <- get_points(stream, n = 101))
+  ### test stop
+  stream <- DSD_Memory(df, outofpoints = "stop")
+  expect_error(points <- get_points(stream, n = 101))
+})
 
-##########################################################################
-context("DSD_ReadCSV")
+test_that("DSD_ReadCSV", {
+  tf <- tempfile()
+  on.exit(unlink(tf), add = TRUE)
 
-write_stream(
-  DSD_Memory(df),
-  file = "test.stream",
-  header = TRUE,
-  info = TRUE,
-  n = 100
-)
+  write_stream(
+    DSD_Memory(df),
+    file = tf,
+    header = TRUE,
+    info = TRUE,
+    n = 100
+  )
 
-stream <- DSD_ReadCSV("test.stream", header = TRUE)
-stream
+  stream <- DSD_ReadCSV(tf, header = TRUE)
+  stream
 
-reset_stream(stream)
-points <- get_points(stream, n = 10, info = TRUE)
-expect_equal(points, df[1:10, ])
-expect_equal(ncol(points), ncol(df))
+  reset_stream(stream)
+  points <- get_points(stream, n = 10, info = TRUE)
+  expect_equal(points, df[1:10, ])
+  expect_identical(ncol(points), ncol(df))
 
-reset_stream(stream)
-points <- get_points(stream, n = 100)
-expect_equivalent(nrow(points), 100L)
-expect_equal(ncol(points), ncol(df))
+  reset_stream(stream)
+  points <- get_points(stream, n = 100)
+  expect_identical(nrow(points), 100L)
+  expect_identical(ncol(points), ncol(df))
 
 
-### check that a failed request does not take any points.
-reset_stream(stream)
-expect_warning(points <- get_points(stream, n = 101))
-expect_equivalent(nrow(points), 100L)
+  ### check that a failed request does not take any points.
+  reset_stream(stream)
+  expect_warning(points <- get_points(stream, n = 101))
+  expect_identical(nrow(points), 100L)
 
-expect_warning(points <- get_points(stream, n = 1))
-expect_equivalent(nrow(points), 0L)
+  expect_warning(points <- get_points(stream, n = 1))
+  expect_identical(nrow(points), 0L)
 
-close_stream(stream)
-stream
+  close_stream(stream)
+  stream
 
-stream <-
-  DSD_ReadCSV("test.stream", header = TRUE, outofpoints = "stop")
-expect_error(points <-
-    get_points(stream, n = 101))
+  stream <-
+    DSD_ReadCSV(tf, header = TRUE, outofpoints = "stop")
+  expect_error(points <-
+      get_points(stream, n = 101))
 
-close_stream(stream)
-#unlink("test.stream")
+  close_stream(stream)
+})
 
-########################################################################
-context("DSD_ReadDB")
+test_that("DSD_ReadDB", {
+  ### NOTE: reset_stream is not implemented for DB connections
 
-### NOTE: reset_stream is not implemented for DB connections
+  skip_if_not_installed("DBI")
+  skip_if_not_installed("RSQLite")
 
-library("RSQLite")
-con <- dbConnect(RSQLite::SQLite(), ":memory:")
-dbWriteTable(con, "gaussians", df)
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  DBI::dbWriteTable(con, "gaussians", df)
 
-### prepare a query result set
-res <- dbSendQuery(con, "SELECT x, y, `.class` FROM gaussians")
-stream <- DSD_ReadDB(res, k = 3)
+  ### prepare a query result set
+  res <- DBI::dbSendQuery(con, "SELECT x, y, `.class` FROM gaussians")
+  stream <- DSD_ReadDB(res, k = 3)
 
-### no reset for this
-expect_error(reset_stream(stream))
+  ### no reset for this
+  expect_error(reset_stream(stream))
 
-points <- get_points(stream, n = 10)
-expect_equivalent(nrow(points), 10L)
-expect_equal(ncol(points), ncol(df))
+  points <- get_points(stream, n = 10)
+  expect_identical(nrow(points), 10L)
+  expect_identical(ncol(points), ncol(df))
 
-expect_warning(points <- get_points(stream, n = 101))
-expect_equivalent(nrow(points), 90L)
+  expect_warning(points <- get_points(stream, n = 101))
+  expect_identical(nrow(points), 90L)
 
-close_stream(stream, disconnect = FALSE)
+  close_stream(stream, disconnect = FALSE)
 
-###
-res <- dbSendQuery(con, "SELECT x, y, `.class` FROM gaussians")
-stream <- DSD_ReadDB(res, k = 3, outofpoints = "stop")
+  ###
+  res <- DBI::dbSendQuery(con, "SELECT x, y, `.class` FROM gaussians")
+  stream <- DSD_ReadDB(res, k = 3, outofpoints = "stop")
 
-expect_error(points <-
-    get_points(stream, n = 101))
+  expect_error(points <-
+      get_points(stream, n = 101))
 
-close_stream(stream, disconnect = FALSE)
+  close_stream(stream, disconnect = FALSE)
 
-## Check general interface
-dsd_inf <- list(
-  DSD_BarsAndGaussians(),
-  DSD_Benchmark(),
-  DSD_Cubes(),
-  DSD_Gaussians(),
-  DSD_mlbenchGenerator("cassini"),
-  DSD_Target(),
-  DSD_UniformNoise()
-)
+  ## Check general interface
+  dsd_inf <- list(
+    DSD_BarsAndGaussians(),
+    DSD_Benchmark(),
+    DSD_Cubes(),
+    DSD_Gaussians(),
+    DSD_mlbenchGenerator("cassini"),
+    DSD_Target(),
+    DSD_UniformNoise()
+  )
 
-res <- dbSendQuery(con, "SELECT x, y, `.class` FROM gaussians")
+  res <- DBI::dbSendQuery(con, "SELECT x, y, `.class` FROM gaussians")
 
-dsd_finite <- list(DSD_Memory(df),
-  #DSD_Mixture,
-  DSD_mlbenchData("PimaIndiansDiabetes"),
-  DSD_ReadDB(res, k = 3),
-  DSD_ReadStream("test.stream", header = TRUE)
-  #DSD_ReadCSV,
-)
+  tf <- tempfile()
+  on.exit(unlink(tf), add = TRUE)
+  write_stream(
+    DSD_Memory(df),
+    file = tf,
+    header = TRUE,
+    info = TRUE,
+    n = 100
+  )
 
-  for (dsd in c(dsd_inf, dsd_finite)) {
-    r <- get_points(dsd, n = 0)
-    expect_equal(nrow(r), 0L)
-    expect_true(inherits(r, "data.frame"))
-    expect_false(!length(grep("^\\.", colnames(r))))
-    r <- get_points(dsd, n = 0, info = FALSE)
-    expect_equal(nrow(r), 0L)
-    expect_true(inherits(r, "data.frame"))
-    expect_true(!length(grep("^\\.", colnames(r))))
+  dsd_finite <- list(
+    DSD_Memory(df),
+    #DSD_Mixture,
+    DSD_mlbenchData("PimaIndiansDiabetes"),
+    DSD_ReadDB(res, k = 3),
+    DSD_ReadStream(tf, header = TRUE)
+    #DSD_ReadCSV,
+  )
 
-    expect_equal(colnames(get_points(dsd, n = 0)), colnames(get_points(dsd, n = 1)))
+    for (dsd in c(dsd_inf, dsd_finite)) {
+      r <- get_points(dsd, n = 0)
+      expect_identical(nrow(r), 0L)
+      expect_s3_class(r, "data.frame")
+      expect_match(colnames(r), "^\\.", all = FALSE)
+      r <- get_points(dsd, n = 0, info = FALSE)
+      expect_identical(nrow(r), 0L)
+      expect_s3_class(r, "data.frame")
+      expect_no_match(colnames(r), "^\\.", all = FALSE)
 
-    r <- get_points(dsd, n = 1)
-    expect_equal(nrow(r), 1L)
-    expect_true(inherits(r, "data.frame"))
-    expect_false(!length(grep("^\\.", colnames(r))))
-    r <- get_points(dsd, n = 1, info = FALSE)
-    expect_equal(nrow(r), 1L)
-    expect_true(inherits(r, "data.frame"))
-    expect_true(!length(grep("^\\.", colnames(r))))
+      expect_equal(colnames(get_points(dsd, n = 0)), colnames(get_points(dsd, n = 1)))
 
-    r <- get_points(dsd, n = 10)
-    expect_equal(nrow(r), 10L)
-    expect_true(inherits(r, "data.frame"))
-    expect_false(!length(grep("^\\.", colnames(r))))
-    r <- get_points(dsd, n = 10, info = FALSE)
-    expect_equal(nrow(r), 10L)
-    expect_true(inherits(r, "data.frame"))
-    expect_true(!length(grep("^\\.", colnames(r))))
-  }
+      r <- get_points(dsd, n = 1)
+      expect_identical(nrow(r), 1L)
+      expect_s3_class(r, "data.frame")
+      expect_match(colnames(r), "^\\.", all = FALSE)
+      r <- get_points(dsd, n = 1, info = FALSE)
+      expect_identical(nrow(r), 1L)
+      expect_s3_class(r, "data.frame")
+      expect_no_match(colnames(r), "^\\.", all = FALSE)
 
-  for (dsd in dsd_inf) {
-    # error
-    expect_error(get_points(dsd, n = -1), "not allowed")
-    expect_error(get_points(dsd, n = -1, info = FALSE), "not allowed")
-  }
+      r <- get_points(dsd, n = 10)
+      expect_identical(nrow(r), 10L)
+      expect_s3_class(r, "data.frame")
+      expect_match(colnames(r), "^\\.", all = FALSE)
+      r <- get_points(dsd, n = 10, info = FALSE)
+      expect_identical(nrow(r), 10L)
+      expect_s3_class(r, "data.frame")
+      expect_no_match(colnames(r), "^\\.", all = FALSE)
+    }
 
-  for (dsd in dsd_finite) {
-    if (!inherits(dsd, "DSD_ReadDB"))
-      reset_stream(dsd)
-    get_points(dsd, n = -1)
-    expect_equal(get_points(dsd, n = -1), get_points(dsd, n = 0))
-  }
+    for (dsd in dsd_inf) {
+      # error
+      expect_error(get_points(dsd, n = -1), "not allowed")
+      expect_error(get_points(dsd, n = -1, info = FALSE), "not allowed")
+    }
 
-### cleanup
-suppressWarnings(lapply(dsd_finite, close_stream))
+    for (dsd in dsd_finite) {
+      if (!inherits(dsd, "DSD_ReadDB"))
+        reset_stream(dsd)
+      get_points(dsd, n = -1)
+      expect_equal(get_points(dsd, n = -1), get_points(dsd, n = 0))
+    }
 
-unlink("test.stream")
+  ### cleanup
+  suppressWarnings(lapply(dsd_finite, close_stream))
+})

--- a/tests/testthat/test-DSF.R
+++ b/tests/testthat/test-DSF.R
@@ -1,106 +1,105 @@
-library("testthat")
-library("stream")
+library(dplyr)
 
 stream1 <- DSD_Gaussians(k = 3, d = 2)
 stream2 <- DSD_Gaussians(k = 1, d = 2)
 
 rename <- function(x, names) {
-  colnames(x) <-  names
+  colnames(x) <- names
   x
 }
 
-context("DSF_Func with a DSD")
+test_that("DSF_Func with a DSD", {
+  skip_if_not_installed("dplyr")
+  # DSF with stream
+  dsfs <- list(
+    stream1 %>% DSF_Func(func = rename, names = c("x", "y")),
+    stream1 %>% DSF_Convolve(kernel = filter_MA(5), dim = 1),
+    stream1 %>% DSF_Downsample(factor = 1),
+    stream1 %>% DSF_dplyr(func = mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = select(!X1)),
+    stream1 %>% DSF_ExponentialMA(alpha = .7),
+    stream1 %>% DSF_Scale()
+  )
 
-library(dplyr)
+  for (stream_dsf in dsfs) {
+    if (interactive()) {
+      print(stream_dsf)
+      cat("\n")
+    }
 
-# DSF with stream
-dsfs <- list(
-  stream1 %>% DSF_Func(func = rename, names = c("x", "y")),
-  stream1 %>% DSF_Convolve(kernel = filter_MA(5), dim = 1),
-  stream1 %>% DSF_Downsample(factor = 1),
-  stream1 %>% DSF_dplyr(func = mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = select(!X1)),
-  stream1 %>% DSF_ExponentialMA(alpha = .7),
-  stream1 %>% DSF_Scale()
-)
+    ps <- get_points(stream_dsf, n = 5)
+    ps$weight <- NULL
+    expect_identical(dim(ps), c(5L, 3L))
 
-for (stream_dsf in dsfs) {
-  if (interactive()) {
-    print(stream_dsf)
-    cat("\n")
+    ps <- get_points(stream_dsf, n = 5, info = FALSE)
+    ps$weight <- NULL
+    expect_identical(dim(ps), c(5L, 2L))
+
+    ps <- get_points(stream_dsf, n = 0)
+    ps$weight <- NULL
+    expect_identical(dim(ps), c(0L, 3L))
+
+    ps <- update(stream_dsf, n = 5)
+    ps$weight <- NULL
+    expect_identical(nrow(ps), 5L)
+
+    ps <- update(stream_dsf, dsd = stream2, n = 5)
+    ps$weight <- NULL
+    expect_identical(nrow(ps), 5L)
+  }
+})
+
+test_that("DSF_Func without a DSD", {
+  skip_if_not_installed("dplyr")
+
+  expect_error(DSF_Scale())
+  points <- get_points(stream1, n = 100, info = FALSE)
+  center <- colMeans(points)
+  scale <- apply(points, MARGIN = 2, sd)
+
+
+  # DSF without stream
+  dsfs <- list(
+    DSF_Func(func = rename, names = c("x", "y")),
+    DSF_Convolve(kernel = filter_MA(5), dim = 1),
+    DSF_Downsample(factor = 1),
+    DSF_dplyr(func = mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = select(!X1)),
+    DSF_ExponentialMA(alpha = .7),
+    DSF_Scale(center = center, scale = scale, dim = c("X1", "X2"))
+  )
+
+  for (dsf in dsfs) {
+    if (interactive()) {
+      print(dsf)
+      cat("\n")
+    }
+
+    # no stream
+    expect_error(get_points(dsf, n = 5))
+
+    # specify stream
+    expect_identical(nrow(update(dsf, dsd = stream2, n = 5)), 5L)
+
+    # use data.frame
+    expect_identical(nrow(update(dsf, dsd = get_points(stream2, n = 5))), 5L)
   }
 
-  ps <- get_points(stream_dsf, n = 5)
-  ps$weight <- NULL
-  expect_equal(dim(ps), c(5L, 3L))
 
-  ps <- get_points(stream_dsf, n = 5, info = FALSE)
-  ps$weight <- NULL
-  expect_equal(dim(ps), c(5L, 2L))
+  # DSF Feature Selection
+  stream <- DSD_Gaussians(k = 3, d = 3)
 
-  ps <- get_points(stream_dsf, n = 0)
-  ps$weight <- NULL
-  expect_equal(dim(ps), c(0L, 3L))
+  stream_2features <- DSF_FeatureSelection(stream, features = c("X1", "X3"))
+  p <- get_points(stream_2features, n = 3)
+  expect_identical(dim(p), c(3L, 3L))
 
-  ps <- update(stream_dsf, n = 5)
-  ps$weight <- NULL
-  expect_equal(nrow(ps), 5L)
+  p <- get_points(stream_2features, n = 3, info = FALSE)
+  expect_identical(dim(p), c(3L, 2L))
 
-  ps <- update(stream_dsf, dsd = stream2, n = 5)
-  ps$weight <- NULL
-  expect_equal(nrow(ps), 5L)
-}
+  p <- get_points(stream_2features, n = 0)
+  expect_identical(dim(p), c(0L, 3L))
 
+  p <- get_points(stream_2features, n = 0, info = FALSE)
+  expect_identical(dim(p), c(0L, 2L))
 
-context("DSF_Func without a DSD")
-
-expect_error(DSF_Scale())
-points <- get_points(stream1, n = 100, info = FALSE)
-center <- colMeans(points)
-scale <- apply(points, MARGIN = 2, sd)
-
-
-# DSF without stream
-dsfs <- list(
-  DSF_Func(func = rename, names = c("x", "y")),
-  DSF_Convolve(kernel = filter_MA(5), dim = 1),
-  DSF_Downsample(factor = 1),
-  DSF_dplyr(func = mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = select(!X1)),
-  DSF_ExponentialMA(alpha = .7),
-  DSF_Scale(center = center, scale = scale, dim = c("X1", "X2"))
-)
-
-for (dsf in dsfs) {
-  if (interactive()) {
-    print(stream_dsf)
-    cat("\n")
-  }
-
-  # no stream
-  expect_error(get_points(dsf, n = 5))
-
-  # specify stream
-  expect_equal(nrow(update(dsf, dsd = stream2, n = 5)), 5L)
-
-  # use data.frame
-  expect_equal(nrow(update(dsf, dsd = get_points(stream2, n = 5))), 5L)
-}
-
-
-# DSF Feature Selection
-stream <- DSD_Gaussians(k = 3, d = 3)
-
-stream_2features <- DSF_FeatureSelection(stream, features = c("X1", "X3"))
-p <- get_points(stream_2features, n = 3)
-expect_equal(dim(p), c(3L, 3L))
-
-p <- get_points(stream_2features, n = 3, info = FALSE)
-expect_equal(dim(p), c(3L, 2L))
-
-p <- get_points(stream_2features, n = 0)
-expect_equal(dim(p), c(0L, 3L))
-
-p <- get_points(stream_2features, n = 0, info = FALSE)
-expect_equal(dim(p), c(0L, 2L))
-
-stream_2features <- DSF_FeatureSelection(stream, features = c("X1", "X4"))
-expect_error(get_points(stream_2features, n = 3, info = FALSE))
+  stream_2features <- DSF_FeatureSelection(stream, features = c("X1", "X4"))
+  expect_error(get_points(stream_2features, n = 3, info = FALSE))
+})

--- a/tests/testthat/test-DSF.R
+++ b/tests/testthat/test-DSF.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 stream1 <- DSD_Gaussians(k = 3, d = 2)
 stream2 <- DSD_Gaussians(k = 1, d = 2)
 
@@ -15,7 +13,9 @@ test_that("DSF_Func with a DSD", {
     stream1 %>% DSF_Func(func = rename, names = c("x", "y")),
     stream1 %>% DSF_Convolve(kernel = filter_MA(5), dim = 1),
     stream1 %>% DSF_Downsample(factor = 1),
-    stream1 %>% DSF_dplyr(func = mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = select(!X1)),
+    stream1 %>% DSF_dplyr(
+      func = dplyr::mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = dplyr::select(!X1)
+    ),
     stream1 %>% DSF_ExponentialMA(alpha = .7),
     stream1 %>% DSF_Scale()
   )
@@ -62,7 +62,9 @@ test_that("DSF_Func without a DSD", {
     DSF_Func(func = rename, names = c("x", "y")),
     DSF_Convolve(kernel = filter_MA(5), dim = 1),
     DSF_Downsample(factor = 1),
-    DSF_dplyr(func = mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = select(!X1)),
+    DSF_dplyr(
+      func = dplyr::mutate(Xsum = X1 + X2)) %>% DSF_dplyr(func = dplyr::select(!X1)
+    ),
     DSF_ExponentialMA(alpha = .7),
     DSF_Scale(center = center, scale = scale, dim = c("X1", "X2"))
   )

--- a/tests/testthat/test-DSF_Scale.R
+++ b/tests/testthat/test-DSF_Scale.R
@@ -1,20 +1,17 @@
-library("testthat")
-library("stream")
+test_that("DSF_Scale", {
+  stream <- DSD_Gaussians(k = 3, d = 2) %>% DSD_Memory(n = 100)
 
-stream <- DSD_Gaussians(k = 3, d = 2) %>% DSD_Memory(n = 100)
-stream
+  scaledStream <- stream %>%  DSF_Scale(n = 100)
 
-scaledStream <- stream %>%  DSF_Scale(n = 100)
+  reset_stream(scaledStream)
+  get_points(stream, n = 5)
+  reset_stream(scaledStream)
+  get_points(scaledStream, n = 5)
 
-reset_stream(scaledStream)
-get_points(stream, n = 5)
-reset_stream(scaledStream)
-get_points(scaledStream, n = 5)
+  reset_stream(scaledStream)
+  expect_equal(round(colMeans(get_points(scaledStream, n = 100, info = FALSE)), digits = getOption("digits")),
+    c(X1 = 0, X2 = 0))
 
-reset_stream(scaledStream)
-expect_equal(round(colMeans(get_points(scaledStream, n = 100, info = FALSE)), digits = getOption("digits")),
-  c(X1 = 0, X2 = 0))
-
-reset_stream(scaledStream)
-expect_equal(apply(get_points(scaledStream, n = 100, info = FALSE), MARGIN = 2, sd), c(X1 = 1, X2 = 1))
-
+  reset_stream(scaledStream)
+  expect_equal(apply(get_points(scaledStream, n = 100, info = FALSE), MARGIN = 2, sd), c(X1 = 1, X2 = 1))
+})

--- a/tests/testthat/test-write_stream.R
+++ b/tests/testthat/test-write_stream.R
@@ -1,67 +1,56 @@
-library(stream)
-library("testthat")
-setwd(tempdir())
+test_that("write_stream", {
+  stream <- DSD_Gaussians(k = 3, d = 5)
+  tf <- tempfile()
+  write_stream(stream, file = tf, n = 10, header = TRUE, info = TRUE)
 
-############################################################################
-context("write_stream")
+  l <- readLines(tf)
+  expect_length(l, 10L + 1L)
 
-stream <- DSD_Gaussians(k = 3, d = 5)
-write_stream(stream, file = "data.txt", n = 10, header = TRUE, info = TRUE)
+  dsd <- DSD_ReadStream(tf, header = TRUE)
 
-l <- readLines("data.txt")
-expect_equal(length(l), 10L + 1L)
+  reset_stream(dsd)
+  p <- get_points(dsd, n = -1)
 
-dsd <- DSD_ReadStream("data.txt", header = TRUE)
+  expect_identical(dim(p), dim(read.csv(text = l)))
 
-reset_stream(dsd)
-p <- get_points(dsd, n = -1)
+  close_stream(dsd)
+  unlink(tf)
 
-expect_equal(dim(p), dim(read.csv(text = l)))
+  # n = -1
+  write_stream(DSD_Memory(stream, 5), file = tf, n = -1, header = TRUE, info = TRUE)
+  l <- readLines(tf)
+  expect_length(l, 5L + 1L)
+  unlink(tf)
 
-close_stream(dsd)
-file.remove("data.txt")
+  # n = 0
+  write_stream(stream, file = tf, n = 0, header = TRUE, info = TRUE)
+  l <- readLines(tf)
+  expect_length(l, 1L)
+  unlink(tf)
+})
 
-# n = -1
-write_stream(DSD_Memory(stream, 5), file = "data.txt", n = -1, header = TRUE, info = TRUE)
+test_that("DST_WriteStream", {
+  stream <- DSD_Gaussians(k = 3, d = 5)
+  tf <- tempfile()
+  on.exit(unlink(tf), add = TRUE)
+  writer <- DST_WriteStream(tf)
+  writer
 
-l <- readLines("data.txt")
-expect_equal(length(l), 5L + 1L)
+  update(writer, stream, n = 0)
+  l <- readLines(tf)
+  expect_length(l, 0L)
 
-file.remove("data.txt")
+  update(writer, stream, n = 5)
+  l <- readLines(tf)
+  expect_length(l, 5L)
 
-# n = 0
+  expect_error(DST_WriteStream(tf, header = TRUE))
+  w2 <- DST_WriteStream(tf, append = TRUE)
+  update(w2, stream, n = 10)
+  l <- readLines(tf)
+  expect_length(l, 15L)
 
-write_stream(stream, file = "data.txt", n = 0, header = TRUE, info = TRUE)
-
-l <- readLines("data.txt")
-expect_equal(length(l), 1L)
-
-file.remove("data.txt")
-
-############################################################################
-
-context("DST_WriteStream")
-
-stream <- DSD_Gaussians(k = 3, d = 5)
-writer <- DST_WriteStream("data.txt")
-writer
-
-update(writer, stream, n = 0)
-l <- readLines("data.txt")
-expect_equal(length(l), 0L)
-
-update(writer, stream, n = 5)
-l <- readLines("data.txt")
-expect_equal(length(l), 5L)
-
-expect_error(DST_WriteStream("data.txt", header = TRUE))
-w2 <- DST_WriteStream("data.txt", append = TRUE)
-update(w2, stream, n = 10)
-l <- readLines("data.txt")
-expect_equal(length(l), 15L)
-
-## cleanup
-close_stream(writer)
-close_stream(w2)
-file.remove("data.txt")
-
+  ## cleanup
+  close_stream(writer)
+  close_stream(w2)
+})


### PR DESCRIPTION
Analogue to the dbscan testthat migration:

- removal of context (deprecated)
- replacement of expect_equivalent() for expect_equal()/expect_identical() (deprecated)
- removal of library calls in test
- move tests into test_that() function
- use of expect_length, expect_match, etc.

Note: 
- There are empty tests: test-DSC_BICO.R:1:1, test-DSC_BIRCH.R:1:1, test-DSC_formula.R:54:1
- Two tests are failing, which were failing before as well: test-DSC_read_write.R:52:3, this seems to be an issue with the read and write of the rds stripping names, I assume due to the caching and uncaching.